### PR TITLE
pg_upgrade: check for views using removed functions

### DIFF
--- a/gpdb-doc/markdown/analytics/pl_container_using.html.md
+++ b/gpdb-doc/markdown/analytics/pl_container_using.html.md
@@ -368,7 +368,7 @@ Record the name of the GPU device ID (0 in the above example) or the device UUID
         <image>localhost/plcontainer_python3_cuda_shared:latest</image> 
         <command>/clientdir/py3client.sh</command> 
         <setting roles="gpadmin"/> 
-        <shared_directory access="ro" container="/clientdir" host="/home/sa/GPDB/install/bin/plcontainer_clients"/> 
+        <shared_directory access="ro" container="/clientdir" host="/usr/local/greenplum-db/bin/plcontainer_clients"/> 
         <device_request type="gpu"> 
             <deviceid>0</deviceid> 
         </device_request> 
@@ -552,6 +552,7 @@ This command provides the PL/Container configuration XML file. Add the backend s
 		<command>/clientdir/py3client.sh</command> 
 		<shared_directory access="ro" container="/clientdir" host="/home/sa/GPDB/install/bin/plcontainer_clients"/> 
 		<backend name="calculate_cluster" /> 
+		<setting enable_network="yes" roles="gpadmin" /> 
 	</runtime> 
 </configuration> 
 ```

--- a/gpdb-doc/markdown/utility_guide/ref/pg_config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pg_config.html.md
@@ -9,7 +9,7 @@ pg_config [<option> ...]
 
 pg_config -? | --help
 
-pg_config --version
+pg_config --gp_version
 ```
 
 ## <a id="section3"></a>Description 
@@ -84,6 +84,9 @@ If more than one option is given, the information is printed in that order, one 
 :   Print the value of the `LIBS` variable that was used for building Greenplum Database. This normally contains `-l` switches for external libraries linked into Greenplum Database.
 
 --version
+:   Print the version of PostgreSQL backend server.
+
+--gp_version
 :   Print the version of Greenplum Database.
 
 ## <a id="section5"></a>Examples 

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -460,6 +460,13 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 		 */
 		context->safeToConvert = false;
 	}
+	else
+	{
+		/*
+		 * For other expressions, we should keep them in original place.
+		 */
+		context->innerQual = make_and_qual(context->innerQual, node);
+	}
 
 	return;
 }

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -708,6 +708,14 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryDown(void **state)
 	expect_value(PQfinish, conn, context.perSegInfos[1].conn);
 	will_be_called(PQfinish);
 
+	will_be_called(StartTransactionCommand);
+	will_be_called(GetTransactionSnapshot);
+	expect_value(probeUpdateConfHistory, primary, context.perSegInfos[0].primary_cdbinfo);
+	expect_value(probeUpdateConfHistory, isSegmentAlive, false);
+	expect_value(probeUpdateConfHistory, hasMirrors, true);
+	will_be_called(probeUpdateConfHistory);
+	will_be_called(CommitTransactionCommand);
+
 	/* No update must happen */
 	bool is_updated = processResponse(&context);
 
@@ -1218,6 +1226,14 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
 	expect_value(PQfinish, conn, context.perSegInfos[0].conn);
 	will_be_called(PQfinish);
 
+	will_be_called(StartTransactionCommand);
+	will_be_called(GetTransactionSnapshot);
+	expect_value(probeUpdateConfHistory, primary, context.perSegInfos[0].primary_cdbinfo);
+	expect_value(probeUpdateConfHistory, isSegmentAlive, true);
+	expect_value(probeUpdateConfHistory, hasMirrors, true);
+	will_be_called(probeUpdateConfHistory);
+	will_be_called(CommitTransactionCommand);
+
 	bool is_updated = processResponse(&context);
 
 	assert_true(is_updated);
@@ -1297,6 +1313,14 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimaryDown(void **state)
 	will_be_called(PQfinish);
 	expect_value(PQfinish, conn, context.perSegInfos[1].conn);
 	will_be_called(PQfinish);
+
+	will_be_called(StartTransactionCommand);
+	will_be_called(GetTransactionSnapshot);
+	expect_value(probeUpdateConfHistory, primary, context.perSegInfos[0].primary_cdbinfo);
+	expect_value(probeUpdateConfHistory, isSegmentAlive, false);
+	expect_value(probeUpdateConfHistory, hasMirrors, true);
+	will_be_called(probeUpdateConfHistory);
+	will_be_called(CommitTransactionCommand);
 
 	bool is_updated = processResponse(&context);
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1683,6 +1683,7 @@ CTranslatorDXLToPlStmt::TranslateDXLTvf(
 	rtfunc->funccoltypes = NIL;
 	rtfunc->funccoltypmods = NIL;
 	rtfunc->funccolcollations = NIL;
+	rtfunc->funccolcount = gpdb::ListLength(target_list);
 	ForEach(lc_target_entry, target_list)
 	{
 		TargetEntry *target_entry = (TargetEntry *) lfirst(lc_target_entry);
@@ -1785,7 +1786,6 @@ CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry(
 		const_expr->constvalue = gpdb::DatumFromPointer(str);
 
 		rtfunc->funcexpr = (Node *) const_expr;
-		rtfunc->funccolcount = (int) num_of_cols;
 	}
 	else
 	{
@@ -1832,6 +1832,7 @@ CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry(
 		rtfunc->funcexpr = (Node *) func_expr;
 	}
 
+	rtfunc->funccolcount = (int) num_of_cols;
 	rtfunc->funcparams = funcparams;
 	// GPDB_91_MERGE_FIXME: collation
 	// set rtfunc->funccoltypemods & rtfunc->funccolcollations?

--- a/src/bin/pg_upgrade/greenplum/check_gp.c
+++ b/src/bin/pg_upgrade/greenplum/check_gp.c
@@ -27,6 +27,7 @@ static void check_online_expansion(void);
 static void check_for_array_of_partition_table_types(ClusterInfo *cluster);
 static void check_multi_column_list_partition_keys(ClusterInfo *cluster);
 static void check_for_plpython2_dependent_functions(ClusterInfo *cluster);
+static void check_views_with_removed_functions(void);
 
 /*
  *	check_greenplum
@@ -47,6 +48,7 @@ check_greenplum(void)
 	check_for_array_of_partition_table_types(&old_cluster);
 	check_multi_column_list_partition_keys(&old_cluster);
 	check_for_plpython2_dependent_functions(&old_cluster);
+	check_views_with_removed_functions();
 }
 
 /*
@@ -815,4 +817,87 @@ teardown_GPDB6_data_type_checks(ClusterInfo *cluster)
 		PQfinish(conn);
 	}
 
+}
+
+static void
+check_views_with_removed_functions()
+{
+	char  output_path[MAXPGPATH];
+	FILE *script = NULL;
+	bool  found = false;
+	int   dbnum;
+	int   i_viewname;
+
+	prep_status("Checking for views with removed functions");
+
+	snprintf(output_path, sizeof(output_path), "views_with_removed_functions.txt");
+
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		int			ntups;
+		int			rowno;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn;
+		bool		db_used = false;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+		PQclear(executeQueryOrDie(conn, "SET search_path TO 'public';"));
+
+		/*
+		 * Disabling track_counts results in a large performance improvement,
+		 * several orders of magnitude, when walking the views in
+		 * view_has_removed_operators.
+		 */
+		PQclear(executeQueryOrDie(conn, "SET track_counts TO off;"));
+
+		/* Install check support function */
+		PQclear(executeQueryOrDie(conn,
+								  "CREATE OR REPLACE FUNCTION "
+								  "view_has_removed_functions(OID) "
+								  "RETURNS BOOL "
+								  "AS '$libdir/pg_upgrade_support' "
+								  "LANGUAGE C STRICT;"));
+		res = executeQueryOrDie(conn,
+								"SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS badviewname "
+								"FROM pg_class c JOIN pg_namespace n on c.relnamespace=n.oid "
+								"WHERE c.relkind = 'v' "
+								"AND c.oid >= 16384 "
+								"AND view_has_removed_functions(c.oid) = TRUE;");
+
+		PQclear(executeQueryOrDie(conn, "DROP FUNCTION view_has_removed_functions(OID);"));
+		PQclear(executeQueryOrDie(conn, "SET search_path to 'pg_catalog';"));
+		PQclear(executeQueryOrDie(conn, "RESET track_counts;"));
+
+		ntups = PQntuples(res);
+		i_viewname = PQfnumber(res, "badviewname");
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
+				pg_fatal("Could not create necessary file:  %s\n", output_path);
+			if (!db_used)
+			{
+				fprintf(script, "Database: %s\n", active_db->db_name);
+				db_used = true;
+			}
+			fprintf(script, "  %s\n", PQgetvalue(res, rowno, i_viewname));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (found)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		gp_fatal_log(
+			   "| Your installation contains views using removed functions.\n"
+			   "| These functions are no longer present on the target version.\n"
+			   "| These views must be updated to use functions supported in the\n"
+			   "| target version or removed before upgrade can continue. A list\n"
+			   "| of the problem views is in the file:\n\t%s\n\n", output_path);
+	}
+	else
+		check_ok();
 }

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -75,7 +75,6 @@ extern bool FtsIsActive(void);
 extern void HandleFtsMessage(const char* query_string);
 extern void probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 									bool IsSegmentAlive, bool IsInSync);
-
 extern bool FtsProbeStartRule(Datum main_arg);
 extern void FtsProbeMain (Datum main_arg);
 extern pid_t FtsProbePID(void);

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -75,6 +75,9 @@ extern bool FtsIsActive(void);
 extern void HandleFtsMessage(const char* query_string);
 extern void probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 									bool IsSegmentAlive, bool IsInSync);
+extern void probeUpdateConfHistory(const CdbComponentDatabaseInfo *primary,
+									bool isSegmentAlive,
+									bool hasMirrors);
 extern bool FtsProbeStartRule(Datum main_arg);
 extern void FtsProbeMain (Datum main_arg);
 extern pid_t FtsProbePID(void);

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -110,6 +110,7 @@ typedef struct
 
 typedef struct
 {
+	bool has_mirrors; /* mirrored or mirrorless cluster */
 	int num_pairs; /* number of primary-mirror pairs FTS wants to probe */
 	fts_segment_info *perSegInfos;
 } fts_context;

--- a/src/test/isolation2/expected/fts_doublefault.out
+++ b/src/test/isolation2/expected/fts_doublefault.out
@@ -1,0 +1,358 @@
+-- to make test deterministic and fast
+!\retcode gpconfig -c gp_fts_mark_mirror_down_grace_period -v 0;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- Get an entry into gp_conf_history for a segment
+-- start_ignore
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop');
+ pg_ctl
+--------
+ OK
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl
+--------
+ OK
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan
+---------------------------
+ t
+(1 row)
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan
+---------------------------
+ t
+(1 row)
+-- end_ignore
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+SELECT 1
+
+-- stop primary in order to promote mirror for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- primary is down, and mirror has now been promoted to primary. Verify
+-1U: select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ t                            
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+(2 rows)
+
+-- stop acting primary in order to trigger double fault for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- trigger double fault on content 0 (FTS_PROBE_FAILED)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+(3 rows)
+
+-- stop mirror for content 1
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 3    | FTS: update role, status, and mode for dbid 3 with contentid 1 to p, u, and n 
+ 6    | FTS: update role, status, and mode for dbid 6 with contentid 1 to m, d, and n 
+(5 rows)
+
+-1U: select wait_until_segments_are_down(2);
+ wait_until_segments_are_down 
+------------------------------
+ t                            
+(1 row)
+
+-- stop primary in order to trigger double fault for content 1
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- trigger double fault on content 1 (FTS_PROMOTE_FAILED)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 3    | FTS: update role, status, and mode for dbid 3 with contentid 1 to p, u, and n 
+ 6    | FTS: update role, status, and mode for dbid 6 with contentid 1 to m, d, and n 
+ 3    | FTS: double fault detected for content id 1                                   
+(6 rows)
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 3    | FTS: update role, status, and mode for dbid 3 with contentid 1 to p, u, and n 
+ 6    | FTS: update role, status, and mode for dbid 6 with contentid 1 to m, d, and n 
+ 3    | FTS: double fault detected for content id 1                                   
+ 5    | FTS: content id 0 is out of double fault, dbid 5 is up                        
+(7 rows)
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 1;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 3    | FTS: update role, status, and mode for dbid 3 with contentid 1 to p, u, and n 
+ 6    | FTS: update role, status, and mode for dbid 6 with contentid 1 to m, d, and n 
+ 3    | FTS: double fault detected for content id 1                                   
+ 5    | FTS: content id 0 is out of double fault, dbid 5 is up                        
+ 3    | FTS: content id 1 is out of double fault, dbid 3 is up                        
+(8 rows)
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Test for when ftsprobe process is killed
+
+-1U: drop table last_timestamp;
+DROP TABLE
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+SELECT 1
+
+-- stop primary in order to promote mirror for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- primary is down, and mirror has now been promoted to primary. Verify
+-1U: select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ t                            
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+(2 rows)
+
+-- stop acting primary in order to trigger double fault for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- trigger double fault on content 0 (FTS_PROBE_FAILED)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+(3 rows)
+
+-- kill the ftsprobe process.
+!\retcode pkill -f ftsprobe;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- restarts ftsprobe, we should see another entry for content 0 doublefault into gp_configuration_history
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 5    | FTS: double fault detected for content id 0                                   
+(4 rows)
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 5    | FTS: double fault detected for content id 0                                   
+ 5    | FTS: content id 0 is out of double fault, dbid 5 is up                        
+(5 rows)
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-1U: drop table last_timestamp;
+DROP TABLE
+
+!\retcode gpconfig -r gp_fts_mark_mirror_down_grace_period;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -32,10 +32,6 @@
 -- end_ignore
 (exited with code 0)
 
--- Helper function
-CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
-CREATE FUNCTION
-
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
  count 

--- a/src/test/isolation2/expected/fts_errors_1.out
+++ b/src/test/isolation2/expected/fts_errors_1.out
@@ -32,10 +32,6 @@
 -- end_ignore
 (exited with code 0)
 
--- Helper function
-CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
-CREATE FUNCTION
-
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
  count 

--- a/src/test/isolation2/expected/fts_mirrorless.out
+++ b/src/test/isolation2/expected/fts_mirrorless.out
@@ -1,0 +1,196 @@
+-- Get an entry into gp_conf_history for any segment
+select pg_ctl((select datadir from gp_segment_configuration c where c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Start of test. Bring two segments down, check entries in gp_configuration_history
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+SELECT 1
+
+-- stop segment for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                      
+------+----------------------------------
+ 2    | FTS: content id 0 dbid 2 is down 
+(1 row)
+
+-- stop segment for content 1
+select pg_ctl((select datadir from gp_segment_configuration c where c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                      
+------+----------------------------------
+ 2    | FTS: content id 0 dbid 2 is down 
+ 3    | FTS: content id 1 dbid 3 is down 
+(2 rows)
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                        
+------+------------------------------------
+ 2    | FTS: content id 0 dbid 2 is down   
+ 3    | FTS: content id 1 dbid 3 is down   
+ 2    | FTS: content id 0 dbid 2 is now up 
+(3 rows)
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 1;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                        
+------+------------------------------------
+ 2    | FTS: content id 0 dbid 2 is down   
+ 3    | FTS: content id 1 dbid 3 is down   
+ 2    | FTS: content id 0 dbid 2 is now up 
+ 3    | FTS: content id 1 dbid 3 is now up 
+(4 rows)
+
+-1U: drop table last_timestamp;
+DROP TABLE
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+SELECT 1
+
+-- stop primary for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                      
+------+----------------------------------
+ 2    | FTS: content id 0 dbid 2 is down 
+(1 row)
+
+-- kill the ftsprobe process.
+!\retcode pkill -f ftsprobe;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- restarts ftsprobe, we should see another entry for content 0 doublefault into gp_configuration_history
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                      
+------+----------------------------------
+ 2    | FTS: content id 0 dbid 2 is down 
+ 2    | FTS: content id 0 dbid 2 is down 
+(2 rows)
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                        
+------+------------------------------------
+ 2    | FTS: content id 0 dbid 2 is down   
+ 2    | FTS: content id 0 dbid 2 is down   
+ 2    | FTS: content id 0 dbid 2 is now up 
+(3 rows)
+
+-1U: drop table last_timestamp;
+DROP TABLE

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -195,3 +195,6 @@ CREATE FUNCTION
 
 CREATE OR REPLACE FUNCTION assert_bogus_file_does_not_exist(datadir text, log_dir text) RETURNS TEXT AS $$ import subprocess import os bogus_file = os.path.join(datadir, log_dir, 'bogusfile') if os.path.exists(bogus_file): raise Exception("bogus file: %s should not exist" % bogus_file) return 'OK' $$ LANGUAGE plpython3u;
 CREATE FUNCTION
+
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE FUNCTION

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -292,6 +292,7 @@ test: segwalrep/hintbit_throttle
 test: fts_manual_probe
 test: fts_session_reset
 test: fts_segment_reset
+test: fts_doublefault
 
 # Reindex tests
 test: reindex/abort_reindex

--- a/src/test/isolation2/mirrorless_schedule
+++ b/src/test/isolation2/mirrorless_schedule
@@ -11,3 +11,6 @@ test: gpdispatch
 test: check_gxid
 test: sync_guc
 test: upgrade_numsegments
+
+# fts tests
+test: fts_mirrorless

--- a/src/test/isolation2/sql/fts_doublefault.sql
+++ b/src/test/isolation2/sql/fts_doublefault.sql
@@ -1,0 +1,124 @@
+-- to make test deterministic and fast
+!\retcode gpconfig -c gp_fts_mark_mirror_down_grace_period -v 0;
+!\retcode gpstop -u;
+
+-- Get an entry into gp_conf_history for a segment
+-- start_ignore
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='m' and c.content=0), 'stop');
+select gp_request_fts_probe_scan();
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+select gp_request_fts_probe_scan();
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_request_fts_probe_scan();
+-- end_ignore
+
+!\retcode gprecoverseg -aF --no-progress;
+!\retcode gprecoverseg -ar;
+
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+
+select gp_request_fts_probe_scan();
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+
+-- stop primary in order to promote mirror for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+
+select gp_request_fts_probe_scan();
+
+-- primary is down, and mirror has now been promoted to primary. Verify
+-1U: select wait_until_segments_are_down(1);
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- stop acting primary in order to trigger double fault for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+
+-- trigger double fault on content 0 (FTS_PROBE_FAILED)
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- stop mirror for content 1
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='m' and c.content=1), 'stop');
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-1U: select wait_until_segments_are_down(2);
+
+-- stop primary in order to trigger double fault for content 1
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=1), 'stop');
+
+-- trigger double fault on content 1 (FTS_PROMOTE_FAILED)
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 1;
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF --no-progress;
+
+!\retcode gprecoverseg -ar;
+
+-- Test for when ftsprobe process is killed
+
+-1U: drop table last_timestamp;
+
+select gp_request_fts_probe_scan();
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+
+-- stop primary in order to promote mirror for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+
+select gp_request_fts_probe_scan();
+
+-- primary is down, and mirror has now been promoted to primary. Verify
+-1U: select wait_until_segments_are_down(1);
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- stop acting primary in order to trigger double fault for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+
+-- trigger double fault on content 0 (FTS_PROBE_FAILED)
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- kill the ftsprobe process.
+!\retcode pkill -f ftsprobe;
+
+-- restarts ftsprobe, we should see another entry for content 0 doublefault into gp_configuration_history
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF --no-progress;
+
+!\retcode gprecoverseg -ar;
+
+-1U: drop table last_timestamp;
+
+!\retcode gpconfig -r gp_fts_mark_mirror_down_grace_period;
+!\retcode gpstop -u;

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -20,27 +20,6 @@
 !\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --coordinatoronly;
 !\retcode gpstop -u;
 
--- Helper function
-CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int)
-RETURNS bool AS
-$$
-declare
-retries int; /* in func */
-begin /* in func */
-  retries := 1200; /* in func */
-  loop /* in func */
-    if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */
-      return true; /* in func */
-    end if; /* in func */
-    if retries <= 0 then /* in func */
-      return false; /* in func */
-    end if; /* in func */
-    perform pg_sleep(0.1); /* in func */
-    retries := retries - 1; /* in func */
-  end loop; /* in func */
-end; /* in func */
-$$ language plpgsql;
-
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
 

--- a/src/test/isolation2/sql/fts_mirrorless.sql
+++ b/src/test/isolation2/sql/fts_mirrorless.sql
@@ -1,0 +1,67 @@
+-- Get an entry into gp_conf_history for any segment
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.content=0), 'stop');
+select gp_request_fts_probe_scan();
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_request_fts_probe_scan();
+
+-- Start of test. Bring two segments down, check entries in gp_configuration_history
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+
+select gp_request_fts_probe_scan();
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+
+-- stop segment for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.content=0), 'stop');
+
+select gp_request_fts_probe_scan();
+
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- stop segment for content 1
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.content=1), 'stop');
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 1;
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-1U: drop table last_timestamp;
+
+select gp_request_fts_probe_scan();
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+
+-- stop primary for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.content=0), 'stop');
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- kill the ftsprobe process.
+!\retcode pkill -f ftsprobe;
+
+-- restarts ftsprobe, we should see another entry for content 0 doublefault into gp_configuration_history
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-1U: drop table last_timestamp;

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -566,3 +566,23 @@ RETURNS TEXT AS $$
         raise Exception("bogus file: %s should not exist" % bogus_file)
     return 'OK'
 $$ LANGUAGE plpython3u;
+
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int)
+RETURNS bool AS
+$$
+declare
+retries int; /* in func */
+begin /* in func */
+  retries := 1200; /* in func */
+  loop /* in func */
+if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */
+      return true; /* in func */
+end if; /* in func */
+    if retries <= 0 then /* in func */
+      return false; /* in func */
+end if; /* in func */
+    perform pg_sleep(0.1); /* in func */
+    retries := retries - 1; /* in func */
+end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14921,5 +14921,45 @@ set session authorization ruser;
 set gp_max_system_slices=10;
 ERROR:  permission denied to set parameter "gp_max_system_slices"
 reset session authorization;
+-- Test that set returning function with multiple columns works with explain
+CREATE FUNCTION srf_attnum() RETURNS TABLE(v1 int, v2 int)
+    LANGUAGE plpgsql NO SQL
+    AS $_$
+BEGIN
+    DROP TABLE IF EXISTS tbl_2_cols;
+    CREATE TEMP TABLE tbl_2_cols (col1 int, col2 int) DISTRIBUTED RANDOMLY;
+    RETURN QUERY SELECT * from tbl_2_cols;
+END;
+$_$;
+NOTICE:  specifying "NO SQL" acts as no operation.
+explain select distinct v1 from srf_attnum();
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ HashAggregate  (cost=12.75..22.75 rows=1000 width=4)
+   Group Key: v1
+   ->  Function Scan on srf_attnum  (cost=0.25..10.25 rows=1000 width=4)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select distinct v1 from srf_attnum();
+NOTICE:  table "tbl_2_cols" does not exist, skipping
+ v1 
+----
+(0 rows)
+
+explain select distinct v2 from srf_attnum();
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ HashAggregate  (cost=12.75..22.75 rows=1000 width=4)
+   Group Key: v2
+   ->  Function Scan on srf_attnum  (cost=0.25..10.25 rows=1000 width=4)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select distinct v2 from srf_attnum();
+ v2 
+----
+(0 rows)
+
 drop user ruser;
 drop table foo, bar;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15016,5 +15016,45 @@ set session authorization ruser;
 set gp_max_system_slices=10;
 ERROR:  permission denied to set parameter "gp_max_system_slices"
 reset session authorization;
+-- Test that set returning function with multiple columns works with explain
+CREATE FUNCTION srf_attnum() RETURNS TABLE(v1 int, v2 int)
+    LANGUAGE plpgsql NO SQL
+    AS $_$
+BEGIN
+    DROP TABLE IF EXISTS tbl_2_cols;
+    CREATE TEMP TABLE tbl_2_cols (col1 int, col2 int) DISTRIBUTED RANDOMLY;
+    RETURN QUERY SELECT * from tbl_2_cols;
+END;
+$_$;
+NOTICE:  specifying "NO SQL" acts as no operation.
+explain select distinct v1 from srf_attnum();
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ HashAggregate  (cost=0.00..0.13 rows=1000 width=4)
+   Group Key: v1
+   ->  Function Scan on srf_attnum  (cost=0.00..0.00 rows=1000 width=4)
+ Optimizer: GPORCA
+(4 rows)
+
+select distinct v1 from srf_attnum();
+NOTICE:  table "tbl_2_cols" does not exist, skipping
+ v1 
+----
+(0 rows)
+
+explain select distinct v2 from srf_attnum();
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ HashAggregate  (cost=0.00..0.13 rows=1000 width=4)
+   Group Key: v2
+   ->  Function Scan on srf_attnum  (cost=0.00..0.00 rows=1000 width=4)
+ Optimizer: GPORCA
+(4 rows)
+
+select distinct v2 from srf_attnum();
+ v2 
+----
+(0 rows)
+
 drop user ruser;
 drop table foo, bar;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -2073,3 +2073,88 @@ select (select max((select t.i))) from t;
 (1 row)
 
 drop table t;
+-- Fix join condition expression lost as pull up sublink to join.
+create table tl1(a int, b int, c int, d int) distributed by (a);
+create table tl2(a int, b int, c int, d int) distributed by (a);
+create table tl3(a int, b int, c int, d int) distributed by (a);
+create table tl4(a int, b int, c int, d int) distributed by (a);
+insert into tl1 values (-1, 3, 1, 0);
+insert into tl2 values (2, 1, 1, 0);
+insert into tl2 values (3, 1, 1, 0);
+insert into tl2 values (1, 1, 1, 0);
+insert into tl3 values (9, 9, 1, 9);
+insert into tl4 values (-1, -1, -1, -1);
+explain(costs off, verbose on)
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: tl1.a, tl1.b, tl1.c, tl1.d
+   ->  Hash Join
+         Output: tl1.a, tl1.b, tl1.c, tl1.d
+         Inner Unique: true
+         Hash Cond: ((tl1.b = "Expr_SUBQUERY".csq_c1) AND (tl1.c = "Expr_SUBQUERY".csq_c0))
+         ->  Seq Scan on public.tl1
+               Output: tl1.a, tl1.b, tl1.c, tl1.d
+         ->  Hash
+               Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+                     ->  Subquery Scan on "Expr_SUBQUERY"
+                           Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+                           ->  Finalize GroupAggregate
+                                 Output: tl2.b, max(tl2.a)
+                                 Group Key: tl2.b
+                                 ->  Sort
+                                       Output: tl2.b, (PARTIAL max(tl2.a))
+                                       Sort Key: tl2.b
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Output: tl2.b, (PARTIAL max(tl2.a))
+                                             Hash Key: tl2.b
+                                             ->  Partial HashAggregate
+                                                   Output: tl2.b, PARTIAL max(tl2.a)
+                                                   Group Key: tl2.b
+                                                   ->  Hash Join
+                                                         Output: tl2.b, tl2.a
+                                                         Hash Cond: (tl4.d = tl2.d)
+                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                               Output: tl4.d
+                                                               ->  Seq Scan on public.tl4
+                                                                     Output: tl4.d
+                                                         ->  Hash
+                                                               Output: tl2.b, tl2.a, tl2.d
+                                                               ->  Seq Scan on public.tl2
+                                                                     Output: tl2.b, tl2.a, tl2.d
+ Optimizer: Postgres-based planner
+ Settings: optimizer = 'off'
+(39 rows)
+
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+ a | b | c | d 
+---+---+---+---
+(0 rows)
+
+drop table tl1;
+drop table tl2;
+drop table tl3;
+drop table tl4;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -2162,3 +2162,86 @@ select (select max((select t.i))) from t;
 (1 row)
 
 drop table t;
+-- Fix join condition expression lost as pull up sublink to join.
+create table tl1(a int, b int, c int, d int) distributed by (a);
+create table tl2(a int, b int, c int, d int) distributed by (a);
+create table tl3(a int, b int, c int, d int) distributed by (a);
+create table tl4(a int, b int, c int, d int) distributed by (a);
+insert into tl1 values (-1, 3, 1, 0);
+insert into tl2 values (2, 1, 1, 0);
+insert into tl2 values (3, 1, 1, 0);
+insert into tl2 values (1, 1, 1, 0);
+insert into tl3 values (9, 9, 1, 9);
+insert into tl4 values (-1, -1, -1, -1);
+explain(costs off, verbose on)
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: tl1.a, tl1.b, tl1.c, tl1.d
+   ->  Hash Join
+         Output: tl1.a, tl1.b, tl1.c, tl1.d
+         Hash Cond: ((tl1.b = (max(tl2.a))) AND (tl1.c = tl2.b))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: tl1.a, tl1.b, tl1.c, tl1.d
+               Hash Key: tl1.c
+               ->  Seq Scan on public.tl1
+                     Output: tl1.a, tl1.b, tl1.c, tl1.d
+         ->  Hash
+               Output: (max(tl2.a)), tl2.b
+               ->  GroupAggregate
+                     Output: max(tl2.a), tl2.b
+                     Group Key: tl2.b
+                     ->  Sort
+                           Output: tl2.a, tl2.b
+                           Sort Key: tl2.b
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: tl2.a, tl2.b
+                                 Hash Key: tl2.b
+                                 ->  Hash Join
+                                       Output: tl2.a, tl2.b
+                                       Hash Cond: (tl2.d = tl4.d)
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                             Output: tl2.a, tl2.b, tl2.d
+                                             Hash Key: tl2.d
+                                             ->  Seq Scan on public.tl2
+                                                   Output: tl2.a, tl2.b, tl2.d
+                                       ->  Hash
+                                             Output: tl4.d
+                                             ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                                   Output: tl4.d
+                                                   Hash Key: tl4.d
+                                                   ->  Seq Scan on public.tl4
+                                                         Output: tl4.d
+ Optimizer: GPORCA
+(37 rows)
+
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+ a | b | c | d 
+---+---+---+---
+(0 rows)
+
+drop table tl1;
+drop table tl2;
+drop table tl3;
+drop table tl4;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3688,6 +3688,21 @@ set session authorization ruser;
 set gp_max_system_slices=10;
 reset session authorization;
 
+-- Test that set returning function with multiple columns works with explain
+CREATE FUNCTION srf_attnum() RETURNS TABLE(v1 int, v2 int)
+    LANGUAGE plpgsql NO SQL
+    AS $_$
+BEGIN
+    DROP TABLE IF EXISTS tbl_2_cols;
+    CREATE TEMP TABLE tbl_2_cols (col1 int, col2 int) DISTRIBUTED RANDOMLY;
+    RETURN QUERY SELECT * from tbl_2_cols;
+END;
+$_$;
+explain select distinct v1 from srf_attnum();
+select distinct v1 from srf_attnum();
+explain select distinct v2 from srf_attnum();
+select distinct v2 from srf_attnum();
+
 drop user ruser;
 drop table foo, bar;
 


### PR DESCRIPTION
Views that use removed functions will cause upgrade to fail. This happens during metadata restore on the target cluster because pg_restore will error trying to create a view using functions that do not exist anymore. This is not ideal as we could be many hours into upgrade before a view using a removed operator causes pg_upgrade to fail. This check calls a support function on the source cluster to check if views using removed functions exist.

sister PRs:
https://github.com/kyeap-vmware/gpupgrade/pull/3
https://github.com/kyeap-vmware/gpdb/pull/3
https://github.com/kyeap-vmware/gpdb/pull/4